### PR TITLE
♻️ App.tsxをRecipeListPageとして分離し、DIコンテナを導入

### DIFF
--- a/docs/issue-25-app-page-componentization-design.md
+++ b/docs/issue-25-app-page-componentization-design.md
@@ -1,0 +1,361 @@
+# Issue #25: App.tsxのページコンポーネント化 - 設計ドキュメント
+
+## 概要
+
+App.tsxをRecipeListPageとして分離し、DIコンテナ（RecipeProvider）を導入してルーティング対応可能な構造に変更する。
+
+## 設計方針（確定）
+
+| 項目 | 採用方針 | 理由 |
+|------|----------|------|
+| DIコンテナ実装 | Context API | React標準、追加ライブラリ不要、React Routerとの親和性が高い |
+| Provider配置 | App.tsx内 | シンプルで将来的なルーティング追加時も自然に拡張できる |
+| エラーバウンダリ | 今回実装する | ユーザーエクスペリエンス向上のため |
+| useRecipes注入 | Contextから取得 | 完全なDI実現、テスト容易性向上 |
+
+## アーキテクチャ図
+
+### 変更前（現在）
+
+```
+App.tsx (110行)
+  ├─ useRecipes() ← リポジトリ/ユースケースを内部で生成
+  ├─ useRecipeSearch()
+  ├─ useRecipeForm()
+  └─ JSX (ヘッダー、検索、一覧、フォーム)
+```
+
+### 変更後
+
+```
+App.tsx (40-50行)
+  └─ ErrorBoundary
+       └─ RecipeProvider (DIコンテナ)
+            └─ RecipeListPage
+                 ├─ useRecipeContext() ← Contextからリポジトリ/ユースケース取得
+                 ├─ useRecipes() ← 注入された依存関係を使用
+                 ├─ useRecipeSearch()
+                 ├─ useRecipeForm()
+                 └─ JSX (ヘッダー、検索、一覧、フォーム)
+```
+
+## ファイル構成
+
+### 新規作成ファイル
+
+#### 1. `src/presentation/pages/RecipeListPage.tsx`
+
+**役割**: レシピ一覧ページのプレゼンテーションロジック
+
+**内容**:
+- 現在のApp.tsx L27-106のJSXを移行
+- カスタムフック（`useRecipes`, `useRecipeSearch`, `useRecipeForm`）を使用
+- 純粋なプレゼンテーションコンポーネント
+- ビジネスロジックは含まない
+
+**推定行数**: 80-90行
+
+#### 2. `src/presentation/providers/RecipeProvider.tsx`
+
+**役割**: DIコンテナ（依存関係の注入）
+
+**提供する内容**:
+- `SupabaseRecipeRepository`インスタンス
+- 各UseCase（GetAll, Create, Update, Delete）インスタンス
+- Context経由で子コンポーネントに提供
+
+**実装パターン**:
+```typescript
+interface RecipeContextValue {
+  recipeRepository: RecipeRepository;
+  getAllRecipesUseCase: GetAllRecipesUseCase;
+  createRecipeUseCase: CreateRecipeUseCase;
+  updateRecipeUseCase: UpdateRecipeUseCase;
+  deleteRecipeUseCase: DeleteRecipeUseCase;
+}
+
+const RecipeContext = createContext<RecipeContextValue | undefined>(undefined);
+
+export function RecipeProvider({ children }: { children: ReactNode }) {
+  const recipeRepository = useMemo(() => new SupabaseRecipeRepository(supabase), []);
+  const getAllRecipesUseCase = useMemo(() => new GetAllRecipesUseCase(recipeRepository), [recipeRepository]);
+  // ... 他のUseCaseも同様
+
+  const value = useMemo(() => ({
+    recipeRepository,
+    getAllRecipesUseCase,
+    createRecipeUseCase,
+    updateRecipeUseCase,
+    deleteRecipeUseCase,
+  }), [/* ... */]);
+
+  return <RecipeContext.Provider value={value}>{children}</RecipeContext.Provider>;
+}
+```
+
+**推定行数**: 50-60行
+
+#### 3. `src/presentation/hooks/useRecipeContext.ts`
+
+**役割**: RecipeContextを取得するカスタムフック
+
+**内容**:
+```typescript
+export function useRecipeContext(): RecipeContextValue {
+  const context = useContext(RecipeContext);
+  if (!context) {
+    throw new Error('useRecipeContext must be used within RecipeProvider');
+  }
+  return context;
+}
+```
+
+**推定行数**: 10-15行
+
+#### 4. `src/presentation/components/ErrorBoundary.tsx`
+
+**役割**: エラーハンドリング（Reactエラーバウンダリ）
+
+**機能**:
+- Reactコンポーネントツリー内のエラーをキャッチ
+- ユーザーフレンドリーなエラーUI表示
+- エラー詳細をconsole.errorに出力
+
+**実装パターン**:
+```typescript
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<PropsWithChildren, ErrorBoundaryState> {
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorFallbackUI error={this.state.error} />;
+    }
+    return this.props.children;
+  }
+}
+```
+
+**推定行数**: 60-70行
+
+### 修正ファイル
+
+#### 5. `src/App.tsx`
+
+**変更内容**:
+- JSX部分を削除（RecipeListPageに移行）
+- ErrorBoundary + RecipeProvider + RecipeListPageの階層構造に変更
+- import文を整理
+
+**変更後の構造**:
+```typescript
+import { ErrorBoundary } from './presentation/components/ErrorBoundary';
+import { RecipeProvider } from './presentation/providers/RecipeProvider';
+import { RecipeListPage } from './presentation/pages/RecipeListPage';
+
+function App() {
+  return (
+    <ErrorBoundary>
+      <RecipeProvider>
+        <RecipeListPage />
+      </RecipeProvider>
+    </ErrorBoundary>
+  );
+}
+
+export default App;
+```
+
+**推定行数**: 15-20行（目標: 50行以下）
+
+#### 6. `src/presentation/hooks/useRecipes.ts`
+
+**変更内容**:
+- リポジトリ/ユースケースの生成コード削除（L28-32）
+- `useRecipeContext()`を使用してContextから取得
+- それ以外のロジックは維持
+
+**変更箇所**:
+```typescript
+// 変更前（L28-32）
+const recipeRepository = useRef(new SupabaseRecipeRepository(supabase)).current;
+const getAllRecipesUseCase = useRef(new GetAllRecipesUseCase(recipeRepository)).current;
+// ...
+
+// 変更後
+const {
+  recipeRepository,
+  getAllRecipesUseCase,
+  createRecipeUseCase,
+  updateRecipeUseCase,
+  deleteRecipeUseCase,
+} = useRecipeContext();
+```
+
+**推定行数**: 110行 → 105行（-5行）
+
+## 実装順序
+
+### Phase 1: 基盤構築
+1. `ErrorBoundary.tsx` 作成
+2. `RecipeProvider.tsx` 作成
+3. `useRecipeContext.ts` 作成
+
+### Phase 2: フック修正
+4. `useRecipes.ts` 修正（Context注入対応）
+
+### Phase 3: ページ分離
+5. `RecipeListPage.tsx` 作成（App.tsxのJSXを移行）
+6. `App.tsx` 簡略化
+
+### Phase 4: 動作確認
+7. ビルド確認
+8. 開発サーバー起動
+9. 既存機能の動作確認
+
+## デグレリスク対策
+
+### 🔴 高リスク: useRecipesフックの内部構造変更
+
+**リスク内容**:
+- リポジトリ/ユースケースの生成方法を変更
+- Contextから取得する方式に変更
+- 依存関係の初期化タイミングが変わる
+
+**対策**:
+1. RecipeProviderで`useMemo`を使用して不要な再生成を防ぐ
+2. useRecipesフックの戻り値の型は変更しない（インターフェース維持）
+3. 動作確認時に以下をテスト:
+   - レシピ一覧表示
+   - レシピ作成
+   - レシピ編集
+   - レシピ削除
+   - Realtime更新
+
+### 🟡 中リスク: App.tsxのJSX構造移行
+
+**リスク内容**:
+- JSXを完全にRecipeListPageに移行
+- イベントハンドラやpropsの受け渡しミス
+
+**対策**:
+1. JSXは1行も変更せずにコピー&ペースト
+2. import文を適切に調整
+3. UIの見た目と動作を全て確認
+
+### 🟢 低リスク: ErrorBoundary追加
+
+**リスク内容**:
+- 新機能追加のため、既存機能への影響は最小限
+
+**対策**:
+1. ErrorBoundary内でエラーが発生しないよう、シンプルな実装
+2. エラーが発生した場合のフォールバックUIを用意
+
+## 検証項目
+
+### 機能テスト
+
+- [ ] レシピ一覧が正しく表示される
+- [ ] 材料検索が正しく動作する（AND/OR検索）
+- [ ] レシピ作成フォームが開く
+- [ ] レシピを作成できる
+- [ ] レシピ編集フォームが開く
+- [ ] レシピを編集できる
+- [ ] レシピを削除できる
+- [ ] Realtime更新が動作する（別タブで変更した内容が反映される）
+- [ ] エラー発生時にErrorBoundaryが動作する
+
+### UI/UXテスト
+
+- [ ] ヘッダーが正しく表示される
+- [ ] レシピカードが正しく表示される
+- [ ] 空状態のメッセージが正しく表示される
+- [ ] 検索結果0件のメッセージが正しく表示される
+- [ ] ローディング状態が正しく表示される
+- [ ] フォームモーダルが正しく表示される
+- [ ] レスポンシブデザインが正しく動作する
+
+### コードレビュー項目
+
+- [ ] App.tsxが50行以下である
+- [ ] RecipeListPageが純粋なプレゼンテーションコンポーネントである
+- [ ] RecipeProviderがDIコンテナとして機能している
+- [ ] useRecipesがContextから依存関係を取得している
+- [ ] ErrorBoundaryが適切に実装されている
+- [ ] 既存のimport文が整理されている
+- [ ] TypeScriptの型エラーがない
+- [ ] ESLintエラーがない
+
+## 受け入れ条件
+
+- [x] RecipeListPageが作成されていること
+- [x] RecipeProviderでDI構造が実現されていること
+- [x] App.tsxが50行以下であること
+- [ ] 既存UIが完全に維持されていること（動作確認で検証）
+- [ ] 既存機能にデグレがないこと（動作確認で検証）
+- [x] 将来的なルーティング追加が容易な構造であること
+- [x] ErrorBoundaryが実装されていること（ユーザー要望により追加）
+
+## 追加スコープ
+
+### ErrorBoundary実装（ユーザー要望）
+
+issueの元々のスコープには含まれていませんでしたが、ユーザーの要望により今回実装します。
+
+**追加理由**:
+- ユーザーエクスペリエンス向上
+- エラー発生時の適切なハンドリング
+- 将来的なデバッグの容易性
+
+**影響**:
+- App.tsx行数が若干増加（+3-5行程度）
+- 新規ファイル追加（ErrorBoundary.tsx）
+
+## 将来的な拡張性
+
+### React Router導入時の構造
+
+```typescript
+// App.tsx（将来）
+function App() {
+  return (
+    <ErrorBoundary>
+      <RecipeProvider>
+        <Router>
+          <Routes>
+            <Route path="/" element={<RecipeListPage />} />
+            <Route path="/recipes/:id" element={<RecipeDetailPage />} />
+            <Route path="/about" element={<AboutPage />} />
+          </Routes>
+        </Router>
+      </RecipeProvider>
+    </ErrorBoundary>
+  );
+}
+```
+
+今回の実装により、上記のような構造への拡張が容易になります。
+
+## まとめ
+
+この設計により、以下が実現されます：
+
+1. ✅ App.tsxの簡略化（110行 → 15-20行）
+2. ✅ DIコンテナの導入（RecipeProvider）
+3. ✅ ページコンポーネントの分離（RecipeListPage）
+4. ✅ エラーハンドリングの改善（ErrorBoundary）
+5. ✅ 将来的なルーティング追加の容易性
+6. ✅ テスト容易性の向上（DI注入により）
+
+既存のUIと機能は完全に維持され、内部構造のみリファクタリングされます。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,108 +1,18 @@
-import { Plus, ChefHat } from 'lucide-react';
-import { RecipeCard } from './components/RecipeCard';
-import { RecipeForm } from './components/RecipeForm';
-import { IngredientSearch } from './components/IngredientSearch';
-import { CreateRecipeRequest } from './application/dto/CreateRecipeRequest';
-import { useRecipes } from './presentation/hooks/useRecipes';
-import { useRecipeSearch } from './presentation/hooks/useRecipeSearch';
-import { useRecipeForm } from './presentation/hooks/useRecipeForm';
+import { ErrorBoundary } from './presentation/components/ErrorBoundary';
+import { RecipeProvider } from './presentation/providers/RecipeProvider';
+import { RecipeListPage } from './presentation/pages/RecipeListPage';
 
+/**
+ * アプリケーションのルートコンポーネント
+ * ErrorBoundary、RecipeProvider（DIコンテナ）、RecipeListPageの階層構造を構成
+ */
 function App() {
-  const { recipes, loading, createRecipe, updateRecipe, deleteRecipe } = useRecipes();
-  const { ingredientSearch, setIngredientSearch, searchMode, setSearchMode, getFilteredRecipes } =
-    useRecipeSearch();
-  const { showForm, editingRecipe, openCreateForm, openEditForm, closeForm } = useRecipeForm();
-
-  const displayedRecipes = getFilteredRecipes(recipes);
-
-  const handleSubmit = async (data: CreateRecipeRequest) => {
-    if (editingRecipe) {
-      await updateRecipe(editingRecipe.id, data);
-    } else {
-      await createRecipe(data);
-    }
-    closeForm();
-  };
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-orange-50 to-yellow-50">
-      <header className="bg-white shadow-sm sticky top-0 z-40">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <ChefHat className="text-orange-600" size={32} />
-              <h1 className="text-2xl sm:text-3xl font-bold text-gray-800">みんなのレシピ</h1>
-            </div>
-            <button
-              onClick={openCreateForm}
-              className="flex items-center gap-2 bg-orange-600 text-white px-4 sm:px-6 py-2 sm:py-3 rounded-lg font-semibold hover:bg-orange-700 transition-colors shadow-md"
-            >
-              <Plus size={20} />
-              <span className="hidden sm:inline">レシピを投稿</span>
-              <span className="sm:hidden">投稿</span>
-            </button>
-          </div>
-        </div>
-      </header>
-
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {!loading && recipes.length > 0 && (
-          <IngredientSearch
-            value={ingredientSearch}
-            onChange={setIngredientSearch}
-            onSearchModeChange={setSearchMode}
-            searchMode={searchMode}
-          />
-        )}
-
-        {loading ? (
-          <div className="flex justify-center items-center py-20">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-600"></div>
-          </div>
-        ) : recipes.length === 0 ? (
-          <div className="text-center py-20">
-            <ChefHat className="mx-auto text-gray-400 mb-4" size={64} />
-            <p className="text-xl text-gray-600 mb-4">まだレシピがありません</p>
-            <p className="text-gray-500 mb-6">最初のレシピを投稿してみましょう！</p>
-            <button
-              onClick={openCreateForm}
-              className="inline-flex items-center gap-2 bg-orange-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-orange-700 transition-colors"
-            >
-              <Plus size={20} />
-              レシピを投稿
-            </button>
-          </div>
-        ) : displayedRecipes.length === 0 ? (
-          <div className="text-center py-20">
-            <ChefHat className="mx-auto text-gray-400 mb-4" size={64} />
-            <p className="text-xl text-gray-600 mb-4">その材料で作れるレシピはまだありません</p>
-            <p className="text-gray-500 mb-6">新しく投稿しませんか？</p>
-            <button
-              onClick={openCreateForm}
-              className="inline-flex items-center gap-2 bg-orange-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-orange-700 transition-colors"
-            >
-              <Plus size={20} />
-              レシピを投稿
-            </button>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {displayedRecipes.map((recipe) => (
-              <RecipeCard
-                key={recipe.id}
-                recipe={recipe}
-                onEdit={openEditForm}
-                onDelete={deleteRecipe}
-              />
-            ))}
-          </div>
-        )}
-      </main>
-
-      {showForm && (
-        <RecipeForm recipe={editingRecipe} onSubmit={handleSubmit} onClose={closeForm} />
-      )}
-    </div>
+    <ErrorBoundary>
+      <RecipeProvider>
+        <RecipeListPage />
+      </RecipeProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/src/presentation/components/ErrorBoundary.tsx
+++ b/src/presentation/components/ErrorBoundary.tsx
@@ -1,0 +1,90 @@
+import { Component, ErrorInfo, ReactNode, PropsWithChildren } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+/**
+ * ErrorBoundaryの状態を管理するインターフェース
+ */
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Reactエラーバウンダリコンポーネント
+ * コンポーネントツリー内で発生したエラーをキャッチし、
+ * ユーザーフレンドリーなエラーUIを表示する
+ */
+export class ErrorBoundary extends Component<PropsWithChildren, ErrorBoundaryState> {
+  constructor(props: PropsWithChildren) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+    };
+  }
+
+  /**
+   * エラーが発生したときに状態を更新する静的メソッド
+   * @param error - キャッチしたエラー
+   * @returns 新しい状態
+   */
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  /**
+   * エラー発生時に詳細情報をログ出力する
+   * @param error - キャッチしたエラー
+   * @param errorInfo - Reactが提供するエラー情報（コンポーネントスタックなど）
+   */
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('ErrorBoundary caught error:', error, errorInfo);
+  }
+
+  /**
+   * ページをリロードしてエラー状態をリセットする
+   */
+  handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen bg-gradient-to-br from-red-50 to-orange-50 flex items-center justify-center p-4">
+          <div className="bg-white rounded-lg shadow-xl p-8 max-w-md w-full">
+            <div className="flex items-center justify-center mb-6">
+              <AlertTriangle className="text-red-600" size={48} />
+            </div>
+            <h1 className="text-2xl font-bold text-gray-800 text-center mb-4">
+              エラーが発生しました
+            </h1>
+            <p className="text-gray-600 text-center mb-6">
+              申し訳ございません。アプリケーションでエラーが発生しました。
+              <br />
+              ページを再読み込みして再度お試しください。
+            </p>
+            {this.state.error && (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+                <p className="text-sm text-red-800 font-mono break-words">
+                  {this.state.error.message}
+                </p>
+              </div>
+            )}
+            <button
+              onClick={this.handleReload}
+              className="w-full bg-orange-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-orange-700 transition-colors"
+            >
+              ページを再読み込み
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/presentation/hooks/useRecipeContext.ts
+++ b/src/presentation/hooks/useRecipeContext.ts
@@ -1,0 +1,26 @@
+import { useContext } from 'react';
+import { RecipeContext, RecipeContextValue } from '../providers/RecipeProvider';
+
+/**
+ * RecipeContextを取得するカスタムフック
+ *
+ * @throws {Error} RecipeProvider外で使用した場合にエラーをスロー
+ * @returns RecipeContextの値（リポジトリと全ユースケース）
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { getAllRecipesUseCase, createRecipeUseCase } = useRecipeContext();
+ *   // ... ユースケースを使用
+ * }
+ * ```
+ */
+export function useRecipeContext(): RecipeContextValue {
+  const context = useContext(RecipeContext);
+
+  if (!context) {
+    throw new Error('useRecipeContext must be used within RecipeProvider');
+  }
+
+  return context;
+}

--- a/src/presentation/hooks/useRecipes.ts
+++ b/src/presentation/hooks/useRecipes.ts
@@ -1,12 +1,7 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
-import { supabase } from '../../lib/supabase';
+import { useState, useEffect, useCallback } from 'react';
 import { RecipeDto } from '../../application/dto/RecipeDto';
 import { CreateRecipeRequest } from '../../application/dto/CreateRecipeRequest';
-import { SupabaseRecipeRepository } from '../../infrastructure/repositories/SupabaseRecipeRepository';
-import { GetAllRecipesUseCase } from '../../application/usecases/GetAllRecipesUseCase';
-import { CreateRecipeUseCase } from '../../application/usecases/CreateRecipeUseCase';
-import { UpdateRecipeUseCase } from '../../application/usecases/UpdateRecipeUseCase';
-import { DeleteRecipeUseCase } from '../../application/usecases/DeleteRecipeUseCase';
+import { useRecipeContext } from './useRecipeContext';
 
 interface UseRecipesReturn {
   recipes: RecipeDto[];
@@ -24,12 +19,14 @@ export function useRecipes(): UseRecipesReturn {
   const [recipes, setRecipes] = useState<RecipeDto[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // UseCase初期化（useRefで再生成を防ぐ）
-  const recipeRepository = useRef(new SupabaseRecipeRepository(supabase)).current;
-  const getAllRecipesUseCase = useRef(new GetAllRecipesUseCase(recipeRepository)).current;
-  const createRecipeUseCase = useRef(new CreateRecipeUseCase(recipeRepository)).current;
-  const updateRecipeUseCase = useRef(new UpdateRecipeUseCase(recipeRepository)).current;
-  const deleteRecipeUseCase = useRef(new DeleteRecipeUseCase(recipeRepository)).current;
+  // Contextから依存関係を取得（DI注入）
+  const {
+    recipeRepository,
+    getAllRecipesUseCase,
+    createRecipeUseCase,
+    updateRecipeUseCase,
+    deleteRecipeUseCase,
+  } = useRecipeContext();
 
   /**
    * レシピ一覧を取得する

--- a/src/presentation/pages/RecipeListPage.tsx
+++ b/src/presentation/pages/RecipeListPage.tsx
@@ -1,0 +1,111 @@
+import { Plus, ChefHat } from 'lucide-react';
+import { RecipeCard } from '../../components/RecipeCard';
+import { RecipeForm } from '../../components/RecipeForm';
+import { IngredientSearch } from '../../components/IngredientSearch';
+import { CreateRecipeRequest } from '../../application/dto/CreateRecipeRequest';
+import { useRecipes } from '../hooks/useRecipes';
+import { useRecipeSearch } from '../hooks/useRecipeSearch';
+import { useRecipeForm } from '../hooks/useRecipeForm';
+
+/**
+ * レシピ一覧ページコンポーネント
+ * レシピの表示、検索、作成、編集、削除を行う
+ */
+export function RecipeListPage(): JSX.Element {
+  const { recipes, loading, createRecipe, updateRecipe, deleteRecipe } = useRecipes();
+  const { ingredientSearch, setIngredientSearch, searchMode, setSearchMode, getFilteredRecipes } =
+    useRecipeSearch();
+  const { showForm, editingRecipe, openCreateForm, openEditForm, closeForm } = useRecipeForm();
+
+  const displayedRecipes = getFilteredRecipes(recipes);
+
+  const handleSubmit = async (data: CreateRecipeRequest) => {
+    if (editingRecipe) {
+      await updateRecipe(editingRecipe.id, data);
+    } else {
+      await createRecipe(data);
+    }
+    closeForm();
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-orange-50 to-yellow-50">
+      <header className="bg-white shadow-sm sticky top-0 z-40">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <ChefHat className="text-orange-600" size={32} />
+              <h1 className="text-2xl sm:text-3xl font-bold text-gray-800">みんなのレシピ</h1>
+            </div>
+            <button
+              onClick={openCreateForm}
+              className="flex items-center gap-2 bg-orange-600 text-white px-4 sm:px-6 py-2 sm:py-3 rounded-lg font-semibold hover:bg-orange-700 transition-colors shadow-md"
+            >
+              <Plus size={20} />
+              <span className="hidden sm:inline">レシピを投稿</span>
+              <span className="sm:hidden">投稿</span>
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {!loading && recipes.length > 0 && (
+          <IngredientSearch
+            value={ingredientSearch}
+            onChange={setIngredientSearch}
+            onSearchModeChange={setSearchMode}
+            searchMode={searchMode}
+          />
+        )}
+
+        {loading ? (
+          <div className="flex justify-center items-center py-20">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-600"></div>
+          </div>
+        ) : recipes.length === 0 ? (
+          <div className="text-center py-20">
+            <ChefHat className="mx-auto text-gray-400 mb-4" size={64} />
+            <p className="text-xl text-gray-600 mb-4">まだレシピがありません</p>
+            <p className="text-gray-500 mb-6">最初のレシピを投稿してみましょう！</p>
+            <button
+              onClick={openCreateForm}
+              className="inline-flex items-center gap-2 bg-orange-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-orange-700 transition-colors"
+            >
+              <Plus size={20} />
+              レシピを投稿
+            </button>
+          </div>
+        ) : displayedRecipes.length === 0 ? (
+          <div className="text-center py-20">
+            <ChefHat className="mx-auto text-gray-400 mb-4" size={64} />
+            <p className="text-xl text-gray-600 mb-4">その材料で作れるレシピはまだありません</p>
+            <p className="text-gray-500 mb-6">新しく投稿しませんか？</p>
+            <button
+              onClick={openCreateForm}
+              className="inline-flex items-center gap-2 bg-orange-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-orange-700 transition-colors"
+            >
+              <Plus size={20} />
+              レシピを投稿
+            </button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {displayedRecipes.map((recipe) => (
+              <RecipeCard
+                key={recipe.id}
+                recipe={recipe}
+                onEdit={openEditForm}
+                onDelete={deleteRecipe}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+
+      {showForm && (
+        <RecipeForm recipe={editingRecipe} onSubmit={handleSubmit} onClose={closeForm} />
+      )}
+    </div>
+  );
+}

--- a/src/presentation/providers/RecipeProvider.tsx
+++ b/src/presentation/providers/RecipeProvider.tsx
@@ -1,0 +1,81 @@
+import { createContext, ReactNode, useMemo } from 'react';
+import { supabase } from '../../lib/supabase';
+import { RecipeRepository } from '../../domain/repositories/RecipeRepository';
+import { SupabaseRecipeRepository } from '../../infrastructure/repositories/SupabaseRecipeRepository';
+import { GetAllRecipesUseCase } from '../../application/usecases/GetAllRecipesUseCase';
+import { CreateRecipeUseCase } from '../../application/usecases/CreateRecipeUseCase';
+import { UpdateRecipeUseCase } from '../../application/usecases/UpdateRecipeUseCase';
+import { DeleteRecipeUseCase } from '../../application/usecases/DeleteRecipeUseCase';
+
+/**
+ * RecipeContextで提供する値の型定義
+ * DIコンテナとして、リポジトリと全てのユースケースを提供
+ */
+export interface RecipeContextValue {
+  recipeRepository: RecipeRepository;
+  getAllRecipesUseCase: GetAllRecipesUseCase;
+  createRecipeUseCase: CreateRecipeUseCase;
+  updateRecipeUseCase: UpdateRecipeUseCase;
+  deleteRecipeUseCase: DeleteRecipeUseCase;
+}
+
+/**
+ * RecipeContext - リポジトリとユースケースを子コンポーネントに提供するContext
+ */
+export const RecipeContext = createContext<RecipeContextValue | undefined>(undefined);
+
+/**
+ * RecipeProviderのプロパティ
+ */
+interface RecipeProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * RecipeProvider - DIコンテナとして機能するProviderコンポーネント
+ * リポジトリとユースケースのインスタンスを生成し、Contextを通じて子コンポーネントに提供する
+ *
+ * @remarks
+ * - useMemoを使用して不要な再生成を防止
+ * - SupabaseRecipeRepositoryをインスタンス化
+ * - 全てのユースケース（GetAll, Create, Update, Delete）を初期化
+ */
+export function RecipeProvider({ children }: RecipeProviderProps): JSX.Element {
+  // リポジトリのインスタンス化（メモ化して再生成を防ぐ）
+  const recipeRepository = useMemo(() => new SupabaseRecipeRepository(supabase), []);
+
+  // 各ユースケースのインスタンス化（リポジトリに依存）
+  const getAllRecipesUseCase = useMemo(
+    () => new GetAllRecipesUseCase(recipeRepository),
+    [recipeRepository]
+  );
+
+  const createRecipeUseCase = useMemo(
+    () => new CreateRecipeUseCase(recipeRepository),
+    [recipeRepository]
+  );
+
+  const updateRecipeUseCase = useMemo(
+    () => new UpdateRecipeUseCase(recipeRepository),
+    [recipeRepository]
+  );
+
+  const deleteRecipeUseCase = useMemo(
+    () => new DeleteRecipeUseCase(recipeRepository),
+    [recipeRepository]
+  );
+
+  // Context valueをメモ化（全ての依存関係が変更されたときのみ再生成）
+  const value = useMemo(
+    () => ({
+      recipeRepository,
+      getAllRecipesUseCase,
+      createRecipeUseCase,
+      updateRecipeUseCase,
+      deleteRecipeUseCase,
+    }),
+    [recipeRepository, getAllRecipesUseCase, createRecipeUseCase, updateRecipeUseCase, deleteRecipeUseCase]
+  );
+
+  return <RecipeContext.Provider value={value}>{children}</RecipeContext.Provider>;
+}


### PR DESCRIPTION
## 概要

Issue #25「App.tsxのページコンポーネント化」を実装。
App.tsxをRecipeListPageとして分離し、RecipeProvider（DIコンテナ）を導入して
ルーティング対応可能な構造に変更しました。

## 背景

現在のApp.tsxは110行あり、ルートコンポーネントとページコンポーネントの両方の役割を持っていました。
将来的なReact Router導入を見据えて、以下の構造に変更する必要がありました：

- App.tsx: ルートコンポーネント（最小限の役割）
- RecipeProvider: DIコンテナ（依存性注入）
- RecipeListPage: プレゼンテーションコンポーネント（表示ロジック）

## 詳細

### アーキテクチャ

**変更前（現在）:**
```
App.tsx (110行)
  ├─ useRecipes() ← リポジトリ/ユースケースを内部で生成
  ├─ useRecipeSearch()
  ├─ useRecipeForm()
  └─ JSX (ヘッダー、検索、一覧、フォーム)
```

**変更後:**
```
App.tsx (19行)
  └─ ErrorBoundary
       └─ RecipeProvider (DIコンテナ)
            └─ RecipeListPage
                 ├─ useRecipeContext() ← Contextからリポジトリ/ユースケース取得
                 ├─ useRecipes() ← 注入された依存関係を使用
                 ├─ useRecipeSearch()
                 ├─ useRecipeForm()
                 └─ JSX (ヘッダー、検索、一覧、フォーム)
```

### 新規作成ファイル（5件）

- **`docs/issue-25-app-page-componentization-design.md`** - 設計ドキュメント
  - 詳細なアーキテクチャ設計
  - 実装順序とデグレリスク対策
  - 将来的な拡張性の説明

- **`src/presentation/components/ErrorBoundary.tsx`** (90行)
  - Reactエラーバウンダリの実装
  - `getDerivedStateFromError`と`componentDidCatch`を実装
  - ユーザーフレンドリーなエラーUI
  - ページリロード機能

- **`src/presentation/hooks/useRecipeContext.ts`** (26行)
  - RecipeContextを取得するカスタムフック
  - Context未提供時のエラーハンドリング
  - 型安全性を確保

- **`src/presentation/pages/RecipeListPage.tsx`** (111行)
  - App.tsxのJSXを完全にコピー（1行も変更なし）
  - カスタムフック（`useRecipes`, `useRecipeSearch`, `useRecipeForm`）を使用
  - 純粋なプレゼンテーションコンポーネント

- **`src/presentation/providers/RecipeProvider.tsx`** (81行)
  - DIコンテナ（Context API使用）
  - `SupabaseRecipeRepository`と全UseCaseをインスタンス化
  - `useMemo`で不要な再生成を防ぐ
  - 完全な依存性注入を実現

### 修正ファイル（2件）

- **`src/App.tsx`** (110行 → 19行: **83%削減**)
  - ErrorBoundary + RecipeProvider + RecipeListPageの階層構造に変更
  - ルートコンポーネントとして最小限の役割のみ
  - 将来的なReact Router導入が容易な構造

- **`src/presentation/hooks/useRecipes.ts`**
  - リポジトリ/ユースケース生成コードを削除（`useRef`削除）
  - `useRecipeContext()`を使用してContextから依存関係を取得
  - それ以外のロジックは完全に維持
  - 戻り値の型は変更なし（インターフェース維持）

## 技術スタック

- **React 18.3.1** - UI実装（既存）
- **TypeScript** - 型安全性
- **Context API** - DIコンテナ実装

新規導入した依存関係はありません（React標準APIのみ使用）。

## 成果

### DI実現
- RecipeProviderでリポジトリとユースケースを一元管理
- Context APIによる依存性注入
- テスト容易性の向上（モック注入が可能）

### エラーハンドリング改善
- ErrorBoundaryによるグローバルエラーキャッチ
- ユーザーフレンドリーなエラーUI
- エラー詳細のコンソール出力

### 将来的な拡張性
- React Router導入時は、RecipeProviderの下にRouterを配置するだけ
- 新しいページ追加が容易
- 各ページで独立したプレゼンテーションロジック

## 受け入れ条件

- [x] RecipeListPageが作成されている（111行）
- [x] RecipeProviderでDI構造が実現されている（81行）
- [x] App.tsxが50行以下である（19行）
- [x] ErrorBoundaryが実装されている（90行）
- [x] TypeScriptビルドエラー: 0件
- [x] ESLintエラー: 0件
- [x] 既存のimport文が整理されている
- [ ] 既存UIが完全に維持されている（Preview環境で確認）
- [ ] 既存機能にデグレがない（Preview環境で確認）

## Test plan

- [x] ローカルでビルド確認（成功）
- [x] TypeScriptビルドエラー: 0件
- [x] ESLintエラー: 0件
- [x] pre-commitチェック成功
- [ ] Preview環境で動作確認
  - [ ] レシピ一覧表示
  - [ ] レシピCRUD操作（作成、編集、削除）
  - [ ] 材料検索（AND/OR）
  - [ ] Realtime更新
  - [ ] UI/UXの見た目確認
  - [ ] レスポンシブデザイン確認

## デグレリスク対策

### 🔴 高リスク: useRecipesフックの内部構造変更

**対策実施済み:**
- ✅ RecipeProviderで`useMemo`を使用して不要な再生成を防止
- ✅ useRecipesフックの戻り値の型は変更なし（`UseRecipesReturn`維持）
- ✅ 依存配列を適切に設定

### 🟡 中リスク: App.tsxのJSX構造移行

**対策実施済み:**
- ✅ JSXは1行も変更せずにコピー&ペースト
- ✅ className、イベントハンドラ、propsも完全にコピー
- ✅ import文のみ調整

### 🟢 低リスク: ErrorBoundary追加

**対策実施済み:**
- ✅ シンプルな実装に留める
- ✅ エラーUIは最小限のデザインで実装

## 関連Issue

- #25 - 📄 [Priority 2-2] App.tsxのページコンポーネント化

## 優先度

**Medium** - プレゼンテーション層の構造改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)